### PR TITLE
Parry Networking/Rework

### DIFF
--- a/Parry/ParryHold.cs
+++ b/Parry/ParryHold.cs
@@ -5,23 +5,38 @@ namespace Parry
 {
     public class ParryHold : BaseState
     {
+        public static float baseMinDuration = 0f;   //Set this if you want to require a bit of a delay before you can release like in RoRR. Scales with attack speed.
+        public static string readySoundString = "Play_merc_sword_impact"; //Plays once minDuration has been crossed
+
+        private bool playedSound;
+        private float minDuration;
+
         public override void OnEnter()
         {
             base.OnEnter();
-            Util.PlaySound("Play_merc_sword_impact", this.gameObject);
+
+            playedSound = false;
+            minDuration = baseMinDuration / this.attackSpeedStat;
+
             this.PlayCrossfade("FullBody, Override", "GroundLight2", "GroundLight.playbackRate", 99f, 0.05f);
-            //Start the parry.
-            this.characterBody.AddBuff(Parry.parryBuffDef);
         }
 
 
         public override void FixedUpdate()
         {
             base.FixedUpdate();
+
+            bool minDurationPassed = base.fixedAge >= minDuration;
+            if (minDurationPassed && !playedSound)
+            {
+                playedSound = true;
+                Util.PlaySound(readySoundString, this.gameObject);
+            }
+
             if (this.isAuthority)
             {
                 bool keyReleased = !(this.inputBank && this.inputBank.skill2.down);
-                if (keyReleased)
+                if (keyReleased && minDurationPassed)
                 {
                     this.outer.SetNextState(new ParryStrike());
                 }


### PR DESCRIPTION
Did some brief testing on a Dedicated server, it should work now. Adjust numbers to your liking.

Fields that need to be set:

ParryHold
- baseMinDuration, can leave it at 0 so that you can parry any time, or you can set it to a small number (dont know what timing RoRR uses) so that you have to wait a bit before you can trigger the parry.

ParryStrike
- enterSoundString, plays on state entry
- NetworkSoundEventDefs, server plays these to tell whether you parried or just did a normal swing.

Numbers on ParryStrike and its timing need adjustment, I'll leave it to you to figure out something that feels right. Instinctively I feel the parry could do more damage, since in Returns a single parry can chunk off a good portion of a Golem's HP earlygame (also Whirlwind only does 2x80% in that game compared to the 2x300% in RoR2).